### PR TITLE
Add License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,47 @@
+MIT License
+
+Copyright (c) 2016 Ben Firshman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+For the ReDoc JavaScript file:
+
+/* The MIT License (MIT)
+ * 
+ * Copyright (c) 2015, Rebilly, Inc. 
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # docker-redoc
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A Docker image which serves [ReDoc](https://rebilly.github.io/ReDoc/) documentation.
 
 To serve `swagger.yaml` in the current directory:
@@ -7,3 +9,7 @@ To serve `swagger.yaml` in the current directory:
     $ docker run bfirsh/redoc -p 80:80 -v $(PWD)/swagger.yaml:/usr/share/nginx/html/swagger.yaml
 
 And it'll be running at [http://localhost](http://localhost).
+
+## License
+
+Copyright (c) 2016 Ben Firshman. Licensed under the [MIT license](LICENSE).


### PR DESCRIPTION
@bfirsh noticed there wasn't a license yet in this repository; I picked MIT, because that's what the ReDoc code is licensed under as well (https://github.com/Rebilly/ReDoc/blob/master/LICENSE), which I appended to the LICENSE. 